### PR TITLE
Allow opts.req and opts.res to be fns

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ http.createServer(function (req, res) {
 }).listen()
 ```
 
+If `opts.req` or `opts.res` is a function, it will be called and its return value will be used to set custom fields.
+
 ## Forward headers
 Determining the origin of a request can be hard when using reverse-proxies.
 It's not too uncommon for users to mask their IP by providing an

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function httpNdjson (req, res, opts, cb) {
   if (headers['http-client-ip']) {
     request.httpClientIp = headers['http-client-ip']
   }
-  if (opts.req) extend(request, opts.req)
+  if (opts.req) extend(request, value(opts.req))
   cb(request)
 
   eos(res, function (err) {
@@ -51,9 +51,13 @@ function httpNdjson (req, res, opts, cb) {
       elapsed: Date.now() - start
     }
     if (size !== null) response.contentLength = size
-    if (opts.res) extend(response, opts.res)
+    if (opts.res) extend(response, value(opts.res))
     cb(response)
   })
 
   return setContentLength
+}
+
+function value (data) {
+  return typeof data === 'function' ? data() : data
 }


### PR DESCRIPTION
Lazy execution allows things like appending response headers:

```js
httpNdjson(req, res, {res: () => ({headers: res.headers})})
```